### PR TITLE
Allow setting the filename in meta tags via the Page plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = function(env, ready) {
     }
 
     NunjucksContent.prototype.getFilename = function() {
-      return this.filepath.relative.replace(/nunjucks$/, 'html');
+      this.filepath.relative = this.filepath.relative.replace(/nunjucks$/, 'html');
+      return NunjucksContent.__super__.getFilename.apply(this, arguments);
     };
 
     NunjucksContent.prototype.getHtml = function() {

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -6,7 +6,9 @@ async = require 'async'
 module.exports = (env, ready) ->
   class NunjucksContent extends env.plugins.Page
     constructor: (@filepath, @metadata, @tpl) ->
-    getFilename: -> @filepath.relative.replace(/nunjucks$/,'html')
+    getFilename: ->
+      @filepath.relative = @filepath.relative.replace(/nunjucks$/,'html')
+      super
     getHtml: -> @tpl.render(@metadata)
 
   class NunjucksGivenLoader


### PR DESCRIPTION
The Page plugin we inherit of allows us to set the filename in all kinds of manners, we should call super to enable that. (See: https://github.com/jnordberg/wintersmith/wiki/Page-Plugin)

In my use case I was generating a `sitemap.xml` and need a different filename.
